### PR TITLE
Fixing case when .lproj don't have strings

### DIFF
--- a/ios-strings.rb
+++ b/ios-strings.rb
@@ -439,7 +439,7 @@ def export_ios(res_path, locale)
 
       $arrays_keys.each { |key|
         arr = lookup_locales(locale, :arrays, key)
-
+        next if not arr
         f.write "\"#{key}\" = (\n"
         arr.each { |value|
           value = export_ios_string(locale, value)
@@ -461,7 +461,7 @@ def export_ios(res_path, locale)
 
       $plurals_keys.each { |key|
         plu = lookup_locales(locale, :plurals, key)
-
+        next if not plu
         f.write "<key>#{key}</key>\n"
         f.write "<dict>\n"
         f.write "    <key>NSStringLocalizedFormatKey</key>\n"


### PR DESCRIPTION
Hi, this is a small fix because method `lookup_locales` can return nil
